### PR TITLE
set device type based on device signature

### DIFF
--- a/atecc.c
+++ b/atecc.c
@@ -176,6 +176,17 @@ int main(int argc, char *argv[])
         exit(2);
     }
 
+    uint8_t revision[4];
+
+    ATECC_RETRY(ret, atcab_info(revision));
+    if(ret != ATCA_SUCCESS) {
+        eprintf("Command atcab_info is failed with status %x\n", ret);
+        return 2;
+    }
+
+    ATCADeviceType dt = atcab_device_type(revision);
+    cfg.devtype = dt;
+
     for (i = 0; i < num_cmds; i++) {
         wordexp_t p;
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+atecc-util (0.4.4) stable; urgency=medium
+
+  * set device type based on device signature
+
+ -- Evgeny Boger <boger@contactless.ru>  Sat, 06 Mar 2021 00:24:58 +0300
+
 atecc-util (0.4.3) stable; urgency=medium
 
   * added -d option for device type discovery


### PR DESCRIPTION
HMAC calulation procedure, for instance, is different for 508A
and 608A models. In order to properly fill devtype for internal
cryptoauthlib use we read the device signature right after init.