### PR TITLE
print cryptoauthlib version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,10 @@ GIT_VERSION:=$(shell git describe --abbrev=6 --dirty --always --tags)
 DEB_VERSION := $(shell head -n 1 debian/changelog  | grep -oh -P "\(\K.*(?=\))")
 CFLAGS+=-DVERSION=\"$(DEB_VERSION)\ \($(GIT_VERSION)\)\"
 
+# add cryptoauthlib version info from Git
+LIBCRYPTOAUTH_VERSION=$(shell git -C $(CRYPTOAUTHDIR) describe --abbrev=6 --dirty --always --tags)
+CFLAGS+=-DLIBCRYPTOAUTH_VERSION=\"$(LIBCRYPTOAUTH_VERSION)\"
+
 all: $(TARGET)
 
 

--- a/atecc.c
+++ b/atecc.c
@@ -26,6 +26,10 @@
 #define VERSION "(unknown version)"
 #endif
 
+#ifndef LIBCRYPTOAUTH_VERSION
+#define LIBCRYPTOAUTH_VERSION "(unknown version)"
+#endif
+
 #ifdef USE_OPENSSL
 #define WITH_OPENSSL ", with OpenSSL"
 #else
@@ -87,6 +91,7 @@ void print_available_cmds(void)
 void print_version(void)
 {
     eprintf("atecc-util " VERSION WITH_OPENSSL ", build " __DATE__ " " __TIME__ "\n");
+    eprintf("cryptoauthlib " LIBCRYPTOAUTH_VERSION "\n");
 }
 
 int print_help(const char *argv0, const char *cmd_name)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+atecc-util (0.4.8) stable; urgency=medium
+
+  * print cryptoauthlib version in version info
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 19 Jul 2022 19:09:05 +0300
+
 atecc-util (0.4.7) stable; urgency=medium
 
   * cryptoauthlib: handle 'Watchdog About to Expire' state properly


### PR DESCRIPTION
This commit adds cryptoauthlib version info to `atecc -v` output.

Example:
```console
# ./atecc -v
atecc-util 0.4.8 (v0.4.7-dirty), build Jul 19 2022 19:11:44
cryptoauthlib 20180115-10-gb976f6
```