### PR TITLE
always send ATECC to idle mode before access

### DIFF
--- a/atecc-asymm.c
+++ b/atecc-asymm.c
@@ -125,6 +125,16 @@ int do_atecc_write_private(int argc, char **argv)
     memset(privatekey_payload, 0x00, 4);
     memcpy(privatekey_payload + 4, privatekey, sizeof(privatekey));
 
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
+
     ATECC_RETRY(status, atcab_priv_write(key_id, privatekey_payload, writekey_id, writekey));
     if (status != ATCA_SUCCESS) {
         eprintf("Command atcab_priv_write is failed with status 0x%x\n", status);
@@ -342,6 +352,16 @@ int do_atecc_verify(int argc, char **argv)
     }
 
     maybe_fclose(signaturefile);
+
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
 
     if (!pubkeyfilename) {
         ATECC_RETRY(status, atcab_verify_stored(digest, signature, slot_id, &verified));

--- a/atecc-auth.c
+++ b/atecc-auth.c
@@ -243,6 +243,16 @@ int do_atecc_auth_check_gendig(int argc, char **argv)
     uint8_t resp[32];
     uint8_t challenge[32];
 
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
+
     do {
         if ((status = atcab_random(challenge)) != ATCA_SUCCESS)
         {

--- a/atecc-config.c
+++ b/atecc-config.c
@@ -196,6 +196,16 @@ int do_atecc_write_config(int argc, char **argv)
         goto _wcexit;
     }
 
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        ret = 2;
+        goto _wcexit;
+    }
 
     bool is_locked;
     status = atcab_is_locked(ATCA_ZONE_CONFIG, &is_locked);

--- a/atecc-data.c
+++ b/atecc-data.c
@@ -71,6 +71,16 @@ int do_atecc_write_data(int argc, char **argv)
         goto _exit;
     }
 
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
+
     /* try to write data to chip */
     status = atcab_write_bytes_zone(ATCA_ZONE_DATA, slot_id, offset,
                 inputbuffer, inputsize);
@@ -137,6 +147,16 @@ int do_atecc_read_data(int argc, char **argv)
         }
 
         maybe_fclose(readkeyfile);
+    }
+
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
     }
 
     /* read data from ATECC */

--- a/atecc-ecdh.c
+++ b/atecc-ecdh.c
@@ -35,6 +35,16 @@ int do_atecc_ecdh(int argc, char **argv)
 
     maybe_fclose(pubkeyfile);
 
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
+
     ATECC_RETRY(status, atcab_ecdh(slot_id, pubkey, pms));
     if (status != ATCA_SUCCESS) {
         eprintf("Command atcab_ecdh is failed with status 0x%x\n", status);

--- a/atecc-hmac.c
+++ b/atecc-hmac.c
@@ -61,6 +61,16 @@ int do_atecc_hmac_write_key(int argc, char **argv)
     maybe_fclose(keyfile);
 
     ATCA_STATUS status;
+    // Force send ATECC to idle mode, so watchdog won't be triggered
+    // in the middle of command execution.
+    // This may happen because of I/O in fread slow enough,
+    // it adds delay between ATECC init sequence in main() and this operation.
+    status = atcab_idle();
+    if (status != ATCA_SUCCESS) {
+        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
+        return 2;
+    }
+
     const char *cmd;
     if (!writekeyfilename) {
         cmd = "atcab_write_zone";

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+atecc-util (0.4.8) stable; urgency=medium
+
+  * always send ATECC to idle mode before access
+    This fix is an extension of previous one for cases when
+    watchdog actually expires during long atecc-util operation
+    without a warning.
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Tue, 19 Jul 2022 22:00:16 +0300
+
 atecc-util (0.4.7) stable; urgency=medium
 
   * cryptoauthlib: handle 'Watchdog About to Expire' state properly


### PR DESCRIPTION
This fix is an extension of previous one for cases when watchdog actually expires during long atecc-util operation without a warning.