### PR TITLE
don't exit if atcab_idle failed

### DIFF
--- a/atecc-asymm.c
+++ b/atecc-asymm.c
@@ -131,8 +131,7 @@ int do_atecc_write_private(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     ATECC_RETRY(status, atcab_priv_write(key_id, privatekey_payload, writekey_id, writekey));
@@ -359,8 +358,7 @@ int do_atecc_verify(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     if (!pubkeyfilename) {

--- a/atecc-auth.c
+++ b/atecc-auth.c
@@ -249,8 +249,7 @@ int do_atecc_auth_check_gendig(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     do {

--- a/atecc-config.c
+++ b/atecc-config.c
@@ -202,9 +202,7 @@ int do_atecc_write_config(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        ret = 2;
-        goto _wcexit;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     bool is_locked;

--- a/atecc-data.c
+++ b/atecc-data.c
@@ -77,8 +77,7 @@ int do_atecc_write_data(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     /* try to write data to chip */
@@ -155,8 +154,7 @@ int do_atecc_read_data(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     /* read data from ATECC */

--- a/atecc-ecdh.c
+++ b/atecc-ecdh.c
@@ -41,8 +41,7 @@ int do_atecc_ecdh(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     ATECC_RETRY(status, atcab_ecdh(slot_id, pubkey, pms));

--- a/atecc-hmac.c
+++ b/atecc-hmac.c
@@ -67,8 +67,7 @@ int do_atecc_hmac_write_key(int argc, char **argv)
     // it adds delay between ATECC init sequence in main() and this operation.
     status = atcab_idle();
     if (status != ATCA_SUCCESS) {
-        eprintf("Command atcab_idle is failed with status 0x%x\n", status);
-        return 2;
+        eprintf("Command atcab_idle is failed with status 0x%x, but let's continue\n", status);
     }
 
     const char *cmd;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 atecc-util (0.4.10) stable; urgency=medium
 
   * don't exit if atcab_idle failed (it may mean that
-    device watchdog has switched it already)
+    device watchdog has switched it to idle mode already)
 
  -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 22 Dec 2022 13:54:08 +0600
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+atecc-util (0.4.10) stable; urgency=medium
+
+  * don't exit if atcab_idle failed (it may mean that
+    device watchdog has switched it already)
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.ru>  Thu, 22 Dec 2022 13:54:08 +0600
+
 atecc-util (0.4.9) stable; urgency=medium
 
   * always send ATECC to idle mode before access


### PR DESCRIPTION
It may mean that device watchdog has switched it already.