### PR TITLE
Fix dump-config output

### DIFF
--- a/atecc-config.c
+++ b/atecc-config.c
@@ -106,6 +106,7 @@ int do_atecc_dump_config(int argc, char **argv)
         return 1;
     }
     dump_config(config_zone);
+    fflush(stdout);
     maybe_restore_stdout(saved_stdout);
 
     return 0;

--- a/atecc-config.c
+++ b/atecc-config.c
@@ -106,7 +106,11 @@ int do_atecc_dump_config(int argc, char **argv)
         return 1;
     }
     dump_config(config_zone);
-    fflush(stdout);
+    if (fflush(stdout) == EOF) {
+        perror("flush config dump output");
+        maybe_restore_stdout(saved_stdout);
+        return 1;
+    }
     maybe_restore_stdout(saved_stdout);
 
     return 0;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+atecc-util (0.4.13) stable; urgency=medium
+
+  * Fix dump-config output
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 31 Mar 2026 12:00:00 +0400
+
 atecc-util (0.4.12) stable; urgency=medium
 
   * Fix lintian

--- a/helpers.c
+++ b/helpers.c
@@ -29,13 +29,28 @@ int maybe_set_stdout(const char *filename)
         return STDOUT_FILENO;
     } else {
         int new_stdout = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644);
-        int saved_stdout;
         if (new_stdout < 0) {
             return -1;
         }
 
-        saved_stdout = dup(STDOUT_FILENO);
-        dup2(new_stdout, STDOUT_FILENO);
+        if (fflush(stdout) != 0) {
+            close(new_stdout);
+            return -1;
+        }
+
+        int saved_stdout = dup(STDOUT_FILENO);
+        if (saved_stdout < 0) {
+            close(new_stdout);
+            return -1;
+        }
+
+        if (dup2(new_stdout, STDOUT_FILENO) < 0) {
+            close(new_stdout);
+            close(saved_stdout);
+            return -1;
+        }
+
+        close(new_stdout);
         return saved_stdout;
     }
 }

--- a/helpers.c
+++ b/helpers.c
@@ -28,7 +28,7 @@ int maybe_set_stdout(const char *filename)
     if (strcmp(filename, "-") == 0) {
         return STDOUT_FILENO;
     } else {
-        int new_stdout = open(filename, O_WRONLY | O_TRUNC);
+        int new_stdout = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0644);
         int saved_stdout;
         if (new_stdout < 0) {
             return -1;


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* output файл не создавался если не существует
* буфер не сбрасывался, что приводило что часть вывода попадала в файл, а часть в stdout
```sh
$ atecc -hdump-config
dump-config: dump ATECC config in human-readable format
Usage: dump-config output.txt\|- [config.bin]
If optional third argument is set, dumps config from binary file.
$ atecc -b 2 -c "dump-config output.txt"
open config dump file for writing: No such file or directory
$ touch output.txt
$ atecc -b 2 -c "dump-config output.txt"
usionDisable bit: 0
X509id: 0
=========================  Slot: 14   ==================
...
```

___________________________________
**Что поменялось для пользователей:**
dump-config работает корректно

___________________________________
**Как проверял/а:**
на вб

