### PR TITLE
Rebuild for bullseye

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
-buildDebSbuild defaultTargets: 'wb5 bullseye-armhf bullseye-arm64 bullseye-host',
+buildDebSbuild defaultTargets: 'bullseye-armhf bullseye-arm64 bullseye-host',
+               defaultWbdevImage: 'contactless/devenv:latest_bullseye',
                defaultRunLintian: true,
                repos: ['release', 'devTools']

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+atecc-util (0.4.13-wb101) stable; urgency=medium
+
+  * Rebuild for bullseye
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 21 Jul 2026 17:53:00 +0400
+
 atecc-util (0.4.13-wb100) stable; urgency=medium
 
   * Take the cross-stack chip lock for the whole run to serialize access


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
```sh
$ apt install atecc-util=0.4.13-wb100
...

The following packages have unmet dependencies:
 atecc-util : Depends: libc6 (>= 2.38) but 2.31-13+deb11u14 is to be installed
E: Unable to correct problems, you have held broken packages.
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


